### PR TITLE
move `order`, `authorize` and `duration_until_renewal_attempt` to `acme`

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -1,11 +1,14 @@
 use crate::*;
-use async_rustls::rustls::sign::{any_ecdsa_type, CertifiedKey};
-use async_rustls::rustls::PrivateKey;
+use async_rustls::rustls::{
+    PrivateKey,
+    internal::pemfile,
+    sign::{CertifiedKey, any_ecdsa_type}
+};
 use async_std::fs::create_dir_all;
 use async_std::path::{Path, PathBuf};
 use base64::URL_SAFE_NO_PAD;
 use http_types::{Method, Response};
-use rcgen::{Certificate, CustomExtension, RcgenError, PKCS_ECDSA_P256_SHA256};
+use rcgen::{Certificate, CustomExtension, RcgenError, PKCS_ECDSA_P256_SHA256, CertificateParams, DistinguishedName};
 use ring::digest::{Context, SHA256};
 use ring::error::{KeyRejected, Unspecified};
 use ring::rand::SystemRandom;
@@ -14,6 +17,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use thiserror::Error;
+
+use futures::future::try_join_all;
+use std::time::Duration;
+use async_std::task::sleep;
+use std::io;
+use chrono::Utc;
+use x509_parser::parse_x509_certificate;
 
 pub const LETS_ENCRYPT_STAGING_DIRECTORY: &str =
     "https://acme-staging-v02.api.letsencrypt.org/directory";
@@ -266,4 +276,141 @@ fn get_header(response: &Response, header: &'static str) -> Result<String, AcmeE
         None => Err(AcmeError::MissingHeader(header)),
         Some(values) => Ok(values.last().to_string()),
     }
+}
+
+/// obtain a new certificate for `domains` from `directory_url`
+/// using the contact info `contact`.
+/// authentication data will be cached in `cache_dir`.
+/// the callback `set_auth_key` is called with the data needed for the ACME TLS challange
+/// returns on success a tupel of:
+/// - the new Certificate Key pair
+/// - the key in PEM
+/// - the Certificate in PEM
+pub async fn order<P, F>(
+    set_auth_key: F,
+    directory_url: impl AsRef<str>,
+    domains: &Vec<String>,
+    cache_dir: Option<P>,
+    contact: &Vec<String>,
+    ) -> Result<(CertifiedKey, String, String), OrderError>
+where
+    P: AsRef<Path>,
+    F: Fn(String, CertifiedKey) -> Result<(), AcmeError>
+{
+    let mut params = CertificateParams::new(domains.clone());
+    params.distinguished_name = DistinguishedName::new();
+    params.alg = &PKCS_ECDSA_P256_SHA256;
+    let cert = rcgen::Certificate::from_params(params)?;
+    let pk = any_ecdsa_type(&PrivateKey(cert.serialize_private_key_der())).unwrap();
+    let directory = Directory::discover(directory_url).await?;
+    let account = Account::load_or_create(directory, cache_dir, contact).await?;
+    let mut order = account.new_order(domains.clone()).await?;
+    loop {
+        order = match order {
+            Order::Pending {
+                authorizations,
+                finalize,
+            } => {
+                let auth_futures = authorizations
+                    .iter()
+                    .map(|url| authorize(&set_auth_key, &account, url));
+                try_join_all(auth_futures).await?;
+                log::info!("completed all authorizations");
+                Order::Ready { finalize }
+            }
+            Order::Ready { finalize } => {
+                log::info!("sending csr");
+                let csr = cert.serialize_request_der()?;
+                account.finalize(finalize, csr).await?
+            }
+            Order::Valid { certificate } => {
+                log::info!("download certificate");
+                let acme_cert_pem = account.certificate(certificate).await?;
+                /*let pems = pem::parse_many(&acme_cert_pem);
+                let cert_chain = pems
+                    .into_iter()
+                    .map(|p| RustlsCertificate(p.contents))
+                    .collect();*/
+                let mut rd = acme_cert_pem.as_bytes();
+                let cert_chain = pemfile::certs(&mut rd)
+                    .map_err(|_e| {
+                        AcmeError::Io(io::Error::new(io::ErrorKind::InvalidInput, "Error reading Cert"))
+                })?;
+                let cert_key = CertifiedKey::new(cert_chain, Arc::new(pk));
+                let pk_pem = cert.serialize_private_key_pem();
+                return Ok((cert_key, pk_pem, acme_cert_pem));
+            }
+            Order::Invalid => return Err(OrderError::BadOrder(order)),
+        }
+    }
+}
+async fn authorize<F>(
+    set_auth_key: &F,
+    account: &Account,
+    url: &String) -> Result<(), OrderError>
+ where F: Fn(String, CertifiedKey) -> Result<(), AcmeError>
+    {
+    let (domain, challenge_url) = match account.auth(url).await? {
+        Auth::Pending {
+            identifier,
+            challenges,
+        } => {
+            let Identifier::Dns(domain) = identifier;
+            log::info!("trigger challenge for {}", &domain);
+            let (challenge, auth_key) = account.tls_alpn_01(&challenges, domain.clone())?;
+            set_auth_key(domain.clone(), auth_key)?;
+            account.challenge(&challenge.url).await?;
+            (domain, challenge.url.clone())
+        }
+        Auth::Valid => return Ok(()),
+        auth => return Err(OrderError::BadAuth(auth)),
+    };
+    for i in 0u8..5 {
+        sleep(Duration::from_secs(1u64 << i)).await;
+        match account.auth(url).await? {
+            Auth::Pending { .. } => {
+                log::info!("authorization for {} still pending", &domain);
+                account.challenge(&challenge_url).await?
+            }
+            Auth::Valid => return Ok(()),
+            auth => return Err(OrderError::BadAuth(auth)),
+        }
+    }
+    Err(OrderError::TooManyAttemptsAuth(domain))
+}
+
+pub fn duration_until_renewal_attempt(cert_key: Option<&CertifiedKey>, err_cnt: usize) -> Duration {
+    let valid_until = match cert_key {
+        None => 0,
+        Some(cert_key) => match cert_key.cert.first() {
+            Some(cert) => match parse_x509_certificate(cert.0.as_slice()) {
+                Ok((_, cert)) => cert.validity().not_after.timestamp(),
+                Err(err) => {
+                    log::error!("could not parse certificate: {}", err);
+                    0
+                }
+            },
+            None => 0,
+        },
+    };
+    let valid_secs = (valid_until - Utc::now().timestamp()).max(0);
+    let wait_secs = Duration::from_secs(valid_secs as u64 / 2);
+    match err_cnt {
+        0 => wait_secs,
+        err_cnt => wait_secs.max(Duration::from_secs(1 << err_cnt)),
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum OrderError {
+    #[error("acme error: {0}")]
+    Acme(#[from] AcmeError),
+    #[error("certificate generation error: {0}")]
+    Rcgen(#[from] RcgenError),
+    #[error("bad order object: {0:?}")]
+    BadOrder(Order),
+    #[error("bad auth object: {0:?}")]
+    BadAuth(Auth),
+    #[error("authorization for {0} failed too many times")]
+    TooManyAttemptsAuth(String),
 }


### PR DESCRIPTION
Hi,

I wanted to use this library for a webserver. My server needs a custom implementation of rustls ResolvesServerCert and thus left me with pretty much copying `order`, `authorize` and `duration_until_renewal_attempt` from resolver.rs.
I figure that might happen to others a well and would like to propose to move the functions out of the resolver and make them `pub`.
I also added the callback `set_auth_key`  to `order` as the way to store the challenge might be different as well.

What do you think?