### PR TITLE
Improve type constraints on `AcmeConfig` methods to allow chaining

### DIFF
--- a/examples/server_low_level.rs
+++ b/examples/server_low_level.rs
@@ -5,7 +5,7 @@ use futures::AsyncWriteExt;
 use futures::StreamExt;
 use rustls_acme::acme::ACME_TLS_ALPN_NAME;
 use rustls_acme::caches::DirCache;
-use rustls_acme::AcmeBuilder;
+use rustls_acme::AcmeConfig;
 use smol::net::TcpListener;
 use smol::spawn;
 use std::path::PathBuf;
@@ -38,7 +38,7 @@ async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let args = Args::parse();
 
-    let mut state = AcmeBuilder::new(args.domains.clone())
+    let mut state = AcmeConfig::new(args.domains.clone())
         .contact(args.email.iter().map(|e| format!("mailto:{}",e)).collect())
         .cache_option(args.cache.clone().map(DirCache::new))
         .state();

--- a/examples/server_simple.rs
+++ b/examples/server_simple.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use futures::AsyncWriteExt;
 use futures::StreamExt;
 use rustls_acme::caches::DirCache;
-use rustls_acme::AcmeBuilder;
+use rustls_acme::AcmeConfig;
 use smol::net::TcpListener;
 use smol::spawn;
 use std::path::PathBuf;
@@ -39,7 +39,7 @@ async fn main() {
         .await
         .unwrap();
 
-    let mut tls_incoming = AcmeBuilder::new(args.domains.clone())
+    let mut tls_incoming = AcmeConfig::new(args.domains.clone())
         .contact(args.email.iter().map(|e| format!("mailto:{}",e)).collect())
         .cache_option(args.cache.clone().map(DirCache::new))
         .incoming(tcp_listener.incoming());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! ```rust,no_run
 //! use futures::prelude::*;
-//! use rustls_acme::{AcmeBuilder, caches::DirCache};
+//! use rustls_acme::{AcmeConfig, caches::DirCache};
 //!
 //! #[smol_potat::main]
 //! async fn main() {
@@ -33,7 +33,7 @@
 //!
 //!     let tcp_listener = smol::net::TcpListener::bind("[::]:443").await.unwrap();
 //!
-//!     let mut tls_incoming = AcmeBuilder::new(vec!["example.com".to_string()])
+//!     let mut tls_incoming = AcmeConfig::new(vec!["example.com".to_string()])
 //!         .contact_push("mailto:admin@example.com")
 //!         .cache(DirCache::new("./rustls_acme_cache"))
 //!         .incoming(tcp_listener.incoming());


### PR DESCRIPTION
By requiring the type parameters of `AcmeConfig` to match the associated
types of `Cache`, rustc can work backwards from a subsequent call to
`.cache` to determine the type of `AcmeConfig`. This allows chaining
methods directly after `AcmeConfig::new(...)`.
