### PR TITLE
feat: allow using native cert store instead of webpki-roots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ axum = ["axum-server", "tokio-util", "tokio"]
 name="low_level_axum"
 required-features=["axum"]
 
+[[example]]
+name="low_level_tokio"
+
 [dependencies]
 futures-rustls = "0.22.2"
 futures = "0.3.21"
@@ -42,6 +45,7 @@ rustls = "0.20.6"
 axum-server = { version = "0.4.1", features = ["tls-rustls"], optional=true }
 tokio-util = { version= "0.7.3", optional= true }
 tokio = { version= "1.20.1", optional= true }
+rustls-native-certs = { version = "0.6.2", optional = true }
 
 [dev-dependencies]
 simple_logger = "2.1.0"

--- a/examples/low_level_axum.rs
+++ b/examples/low_level_axum.rs
@@ -27,6 +27,11 @@ struct Args {
     #[clap(long)]
     prod: bool,
 
+    #[cfg(feature = "rustls-native-certs")]
+    /// Custom acme directory
+    #[clap(long)]
+    directory: Option<String>,
+
     #[clap(short, long, default_value = "443")]
     port: u16,
 }
@@ -36,11 +41,17 @@ async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let args = Args::parse();
 
-    let mut state = AcmeConfig::new(args.domains)
+    let acme_config = AcmeConfig::new(args.domains)
         .contact(args.email.iter().map(|e| format!("mailto:{}", e)))
-        .cache_option(args.cache.clone().map(DirCache::new))
-        .directory_lets_encrypt(args.prod)
-        .state();
+        .cache_option(args.cache.clone().map(DirCache::new));
+    #[cfg(feature = "rustls-native-certs")]
+    let acme_config = match args.directory {
+        Some(dir) => acme_config.directory(&dir),
+        None => acme_config.directory_lets_encrypt(args.prod),
+    };
+    #[cfg(not(feature = "rustls-native-certs"))]
+    let acme_config = acme_config.directory_lets_encrypt(args.prod);
+    let mut state = acme_config.state();
     let rustls_config = ServerConfig::builder()
         .with_safe_defaults()
         .with_no_client_auth()

--- a/examples/low_level_tokio.rs
+++ b/examples/low_level_tokio.rs
@@ -29,6 +29,11 @@ struct Args {
     #[clap(long)]
     prod: bool,
 
+    #[cfg(feature = "rustls-native-certs")]
+    /// Custom acme directory
+    #[clap(long)]
+    directory: Option<String>,
+
     #[clap(short, long, default_value = "443")]
     port: u16,
 }
@@ -38,11 +43,17 @@ async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let args = Args::parse();
 
-    let mut state = AcmeConfig::new(args.domains)
+    let acme_config = AcmeConfig::new(args.domains)
         .contact(args.email.iter().map(|e| format!("mailto:{}", e)))
-        .cache_option(args.cache.clone().map(DirCache::new))
-        .directory_lets_encrypt(args.prod)
-        .state();
+        .cache_option(args.cache.clone().map(DirCache::new));
+    #[cfg(feature = "rustls-native-certs")]
+    let acme_config = match args.directory {
+        Some(dir) => acme_config.directory(&dir),
+        None => acme_config.directory_lets_encrypt(args.prod),
+    };
+    #[cfg(not(feature = "rustls-native-certs"))]
+    let acme_config = acme_config.directory_lets_encrypt(args.prod);
+    let mut state = acme_config.state();
     let rustls_config = ServerConfig::builder()
         .with_safe_defaults()
         .with_no_client_auth()


### PR DESCRIPTION
Implemented via feature flag: rustls-native-certs
make low_level examples work with custom ACME ca

Fixes #30 