### PR TITLE
Disable http-types default features such as cookie

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ futures-rustls = "0.24"
 futures = "0.3.21"
 rcgen = "0.10"
 async-h1 = "2.3.3"
-http-types = "2.12.0"
+http-types = { version = "2.12.0", default-features = false }
 serde_json = "1.0.81"
 serde = "1.0.137"
 ring = { version = "0.16.20", features = ["std"] }


### PR DESCRIPTION
The default cookie feature of http-types drags in a lot of hash/crypto dependencies that are also outdated. This causes bloat and dependency problems for users of the crate.