### PR TITLE
Patch CVE-2020-26235 for chrono crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ webpki-roots = "0.23"
 pem = "1.0.2"
 thiserror = "1.0.31"
 x509-parser = "0.13.2"
-chrono = "0.4.19"
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 url = "2.2.2"
 async-trait = "0.1.53"
 smol = "1.3"


### PR DESCRIPTION
I'm using the `rustls-acme` crate in [arb](https://github.com/tyjvazum/arb), where I encountered a security alert ([discussed here](https://github.com/chronotope/chrono/issues/602)) due to the version of the `time` crate that the `chrono` crate was using. I fixed it in `arb`, but the issue persisted since `rustls-acme` also uses `chrono`, so I made this small change to the `Cargo.toml` file to fix it. I've tested everything and am confident it's the correct fix, until `chrono` is able to release a version that they plan on removing the `time` dependency from entirely.

I'm using a patched version of `rustls-acme` for `arb` in the meantime (which if looked at, please ignore the formatting changes that were required by my workflow), that I'd prefer to remove if this change can be merged into the `rustls-acme` crate.