### PR TITLE
Upgrade dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4.17"
 webpki-roots = "0.26"
 pem = "3.0.3"
 thiserror = "1.0.31"
-x509-parser = "0.13.2"
+x509-parser = "0.15.1"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 async-trait = "0.1.53"
 async-io = "2.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.137", features=["derive"] }
 ring = { version = "0.17.7", features = ["std"] }
 base64 = "0.21.7"
 log = "0.4.17"
-webpki-roots = "0.25"
+webpki-roots = "0.26"
 pem = "1.0.2"
 thiserror = "1.0.31"
 x509-parser = "0.13.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ blocking = "1.4.1"
 simple_logger = "2.1.0"
 structopt = "0.3.26"
 clap = { version = "3.1.18", features = ["derive"] }
-smol-potat = "1.1.2"
 axum = "0.7"
 tokio = { version="1.35.1", features = ["full"] }
 tokio-stream = { version="0.1.14", features = ["net"] }
@@ -45,6 +44,8 @@ tokio-util = { version="0.7.10", features = ["compat"] }
 warp = "0.3.4"
 smol = "2.0.0"
 tokio-rustls = "0.25"
+smol-macros = "0.1.0"
+macro_rules_attribute = "0.2.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ blocking = "1.4.1"
 
 [dev-dependencies]
 simple_logger = "2.1.0"
-structopt = "0.3.26"
 clap = { version = "3.1.18", features = ["derive"] }
 axum = "0.7"
 tokio = { version="1.35.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["asynchronous", "cryptography", "network-programming"]
 [dependencies]
 futures-rustls = "0.25"
 futures = "0.3.21"
-rcgen = "0.10"
+rcgen = "0.12"
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features=["derive"] }
 ring = { version = "0.17.7", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ http = "1"
 blocking = "1.4.1"
 
 [dev-dependencies]
-simple_logger = "2.1.0"
+simple_logger = "4.3.3"
 clap = { version = "3.1.18", features = ["derive"] }
 axum = "0.7"
 tokio = { version="1.35.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0.31"
 x509-parser = "0.13.2"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 async-trait = "0.1.53"
-async-io = "1.6.0"
+async-io = "2.3.0"
 tokio = { version= "1.20.1", optional= true }
 tokio-util = { version="0.7.3", features = ["compat"], optional=true }
 axum-server = { version = "0.6", features = ["tls-rustls"], optional=true }
@@ -43,7 +43,7 @@ tokio = { version="1.35.1", features = ["full"] }
 tokio-stream = { version="0.1.14", features = ["net"] }
 tokio-util = { version="0.7.10", features = ["compat"] }
 warp = "0.3.4"
-smol = "1.3.0"
+smol = "2.0.0"
 tokio-rustls = "0.25"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ ring = { version = "0.17.7", features = ["std"] }
 base64 = "0.21.7"
 log = "0.4.17"
 webpki-roots = "0.26"
-pem = "1.0.2"
+pem = "3.0.3"
 thiserror = "1.0.31"
 x509-parser = "0.13.2"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rcgen = "0.12"
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features=["derive"] }
 ring = { version = "0.17.7", features = ["std"] }
-base64 = "0.13.0"
+base64 = "0.21.7"
 log = "0.4.17"
 webpki-roots = "0.25"
 pem = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.21"
 rcgen = "0.10"
 serde_json = "1.0.81"
 serde = { version = "1.0.137", features=["derive"] }
-ring = { version = "0.16.20", features = ["std"] }
+ring = { version = "0.17.7", features = ["std"] }
 base64 = "0.13.0"
 log = "0.4.17"
 webpki-roots = "0.25"

--- a/examples/high_level.rs
+++ b/examples/high_level.rs
@@ -31,7 +31,7 @@ struct Args {
     port: u16,
 }
 
-#[smol_potat::main]
+#[macro_rules_attribute::apply(smol_macros::main!)]
 async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let args = Args::parse();

--- a/examples/low_level.rs
+++ b/examples/low_level.rs
@@ -33,7 +33,7 @@ struct Args {
     port: u16,
 }
 
-#[smol_potat::main]
+#[macro_rules_attribute::apply(smol_macros::main!)]
 async fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
     let args = Args::parse();

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::https_helper::{https, HttpsRequestError};
 use crate::jose::{key_authorization_sha256, sign, JoseError};
-use base64::URL_SAFE_NO_PAD;
+use base64::prelude::*;
 use futures_rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use futures_rustls::rustls::crypto::ring::sign::any_ecdsa_type;
 use futures_rustls::rustls::{sign::CertifiedKey, ClientConfig};
@@ -101,7 +101,7 @@ impl Account {
         Ok(serde_json::from_str(&response.1)?)
     }
     pub async fn finalize(&self, client_config: &Arc<ClientConfig>, url: impl AsRef<str>, csr: Vec<u8>) -> Result<Order, AcmeError> {
-        let payload = format!("{{\"csr\":\"{}\"}}", base64::encode_config(csr, URL_SAFE_NO_PAD));
+        let payload = format!("{{\"csr\":\"{}\"}}", BASE64_URL_SAFE_NO_PAD.encode(csr));
         let response = self.request(client_config, &url, &payload).await?;
         Ok(serde_json::from_str(&response.1)?)
     }

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -8,7 +8,7 @@ use futures_rustls::rustls::crypto::ring::sign::any_ecdsa_type;
 use futures_rustls::rustls::{sign::CertifiedKey, ClientConfig};
 use http::header::ToStrError;
 use http::{Method, Response};
-use rcgen::{Certificate, CustomExtension, RcgenError, PKCS_ECDSA_P256_SHA256};
+use rcgen::{Certificate, CustomExtension, PKCS_ECDSA_P256_SHA256};
 use ring::error::{KeyRejected, Unspecified};
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING};
@@ -221,7 +221,7 @@ pub enum AcmeError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("certificate generation error: {0}")]
-    Rcgen(#[from] RcgenError),
+    Rcgen(#[from] rcgen::Error),
     #[error("JOSE error: {0}")]
     Jose(#[from] JoseError),
     #[error("JSON error: {0}")]

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -53,7 +53,7 @@ impl Account {
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
     {
-        let key_pair = EcdsaKeyPair::from_pkcs8(ALG, key_pair)?;
+        let key_pair = EcdsaKeyPair::from_pkcs8(ALG, key_pair, &SystemRandom::new())?;
         let contact: Vec<&'a str> = contact.into_iter().map(AsRef::<str>::as_ref).collect();
         let payload = json!({
             "termsOfServiceAgreed": true,

--- a/src/caches/dir.rs
+++ b/src/caches/dir.rs
@@ -1,5 +1,6 @@
 use crate::{AccountCache, CertCache};
 use async_trait::async_trait;
+use base64::prelude::*;
 use blocking::unblock;
 use ring::digest::{Context, SHA256};
 use std::io::ErrorKind;
@@ -37,7 +38,7 @@ impl<P: AsRef<Path> + Send + Sync> DirCache<P> {
             ctx.update(&[0])
         }
         ctx.update(directory_url.as_ref().as_bytes());
-        let hash = base64::encode_config(ctx.finish(), base64::URL_SAFE_NO_PAD);
+        let hash = BASE64_URL_SAFE_NO_PAD.encode(ctx.finish());
         format!("cached_account_{}", hash)
     }
     fn cached_cert_file_name(domains: &[String], directory_url: impl AsRef<str>) -> String {
@@ -47,7 +48,7 @@ impl<P: AsRef<Path> + Send + Sync> DirCache<P> {
             ctx.update(&[0])
         }
         ctx.update(directory_url.as_ref().as_bytes());
-        let hash = base64::encode_config(ctx.finish(), base64::URL_SAFE_NO_PAD);
+        let hash = BASE64_URL_SAFE_NO_PAD.encode(ctx.finish());
         format!("cached_cert_{}", hash)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,10 +51,13 @@ impl AcmeConfig<Infallible, Infallible> {
     ///
     pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
         let mut root_store = RootCertStore::empty();
-        root_store.extend(TLS_SERVER_ROOTS.iter().map(|ta| TrustAnchor {
-            subject: ta.subject.into(),
-            subject_public_key_info: ta.spki.into(),
-            name_constraints: ta.name_constraints.map(Into::into),
+        root_store.extend(TLS_SERVER_ROOTS.iter().map(|ta| {
+            let ta = ta.to_owned();
+            TrustAnchor {
+                subject: ta.subject.into(),
+                subject_public_key_info: ta.subject_public_key_info.into(),
+                name_constraints: ta.name_constraints.map(Into::into),
+            }
         }));
         let client_config = Arc::new(ClientConfig::builder().with_root_certificates(root_store).with_no_client_auth());
         AcmeConfig {

--- a/src/jose.rs
+++ b/src/jose.rs
@@ -1,4 +1,4 @@
-use base64::URL_SAFE_NO_PAD;
+use base64::prelude::*;
 use ring::digest::{digest, Digest, SHA256};
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair};
@@ -11,10 +11,10 @@ pub(crate) fn sign(key: &EcdsaKeyPair, kid: Option<&str>, nonce: String, url: &s
         Some(_) => None,
     };
     let protected = Protected::base64(jwk, kid, nonce, url)?;
-    let payload = base64::encode_config(payload, URL_SAFE_NO_PAD);
+    let payload = BASE64_URL_SAFE_NO_PAD.encode(payload);
     let combined = format!("{}.{}", &protected, &payload);
     let signature = key.sign(&SystemRandom::new(), combined.as_bytes())?;
-    let signature = base64::encode_config(signature.as_ref(), URL_SAFE_NO_PAD);
+    let signature = BASE64_URL_SAFE_NO_PAD.encode(signature.as_ref());
     let body = Body {
         protected,
         payload,
@@ -57,7 +57,7 @@ impl<'a> Protected<'a> {
             url,
         };
         let protected = serde_json::to_vec(&protected)?;
-        Ok(base64::encode_config(protected, URL_SAFE_NO_PAD))
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(protected))
     }
 }
 
@@ -80,8 +80,8 @@ impl Jwk {
             crv: "P-256",
             kty: "EC",
             u: "sig",
-            x: base64::encode_config(x, URL_SAFE_NO_PAD),
-            y: base64::encode_config(y, URL_SAFE_NO_PAD),
+            x: BASE64_URL_SAFE_NO_PAD.encode(x),
+            y: BASE64_URL_SAFE_NO_PAD.encode(y),
         }
     }
     pub(crate) fn thumb_sha256_base64(&self) -> Result<String, JoseError> {
@@ -93,7 +93,7 @@ impl Jwk {
         };
         let json = serde_json::to_vec(&jwk_thumb)?;
         let hash = digest(&SHA256, &json);
-        Ok(base64::encode_config(hash, URL_SAFE_NO_PAD))
+        Ok(BASE64_URL_SAFE_NO_PAD.encode(hash))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! use futures::prelude::*;
 //! use rustls_acme::{AcmeConfig, caches::DirCache};
 //!
-//! #[smol_potat::main]
+//! #[macro_rules_attribute::apply(smol_macros::main!)]
 //! async fn main() {
 //!     simple_logger::init_with_level(log::Level::Info).unwrap();
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@ use futures::ready;
 use futures_rustls::pki_types::{CertificateDer as RustlsCertificate, PrivateKeyDer, PrivatePkcs8KeyDer};
 use futures_rustls::rustls::sign::CertifiedKey;
 use futures_rustls::rustls::{crypto::ring::sign::any_ecdsa_type, ServerConfig};
-use rcgen::{CertificateParams, DistinguishedName, RcgenError, PKCS_ECDSA_P256_SHA256};
+use rcgen::{CertificateParams, DistinguishedName, PKCS_ECDSA_P256_SHA256};
 use std::convert::Infallible;
 use std::fmt::Debug;
 use std::future::Future;
@@ -73,7 +73,7 @@ pub enum OrderError {
     #[error("acme error: {0}")]
     Acme(#[from] AcmeError),
     #[error("certificate generation error: {0}")]
-    Rcgen(#[from] RcgenError),
+    Rcgen(#[from] rcgen::Error),
     #[error("bad order object: {0:?}")]
     BadOrder(Order),
     #[error("bad auth object: {0:?}")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -176,11 +176,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         if pems.len() < 2 {
             return Err(CertParseError::TooFewPem(pems.len()));
         }
-        let pk = match any_ecdsa_type(&PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(pems.remove(0).contents))) {
+        let pk = match any_ecdsa_type(&PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(pems.remove(0).contents()))) {
             Ok(pk) => pk,
             Err(_) => return Err(CertParseError::InvalidPrivateKey),
         };
-        let cert_chain: Vec<RustlsCertificate> = pems.into_iter().map(|p| RustlsCertificate::from(p.contents)).collect();
+        let cert_chain: Vec<RustlsCertificate> = pems.into_iter().map(|p| RustlsCertificate::from(p.into_contents())).collect();
         let validity = match parse_x509_certificate(&cert_chain[0]) {
             Ok((_, cert)) => {
                 let validity = cert.validity();


### PR DESCRIPTION
This PR upgrades most dependencies to their current versions.

- Upgrade smol and async-io
- Upgrade to current ring
- Upgrade to current rcgen
- Upgrade to current base64
- Upgrade to current webpki-roots
- Switch from smol_potat to smol-macros
- Upgrade to current pem
- Remove unused structopt dependency
- Upgrade to current x509-parser
- Upgrade to current simple_logger
