### PR TITLE
Remove chrono dependency and use transitive time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ webpki-roots = "0.26"
 pem = "3.0.3"
 thiserror = "1.0.31"
 x509-parser = "0.15.1"
-chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
+time = "0.3.34"
 async-trait = "0.1.53"
 async-io = "2.3.0"
 tokio = { version= "1.20.1", optional= true }


### PR DESCRIPTION
While adding this as a dependency to my project, I noticed my dependency tree kind of blew up due to the inclusion of `chrono` (it added unrelated things related to wasm and Android, for example). In an effort to reduce my dependency count I decided to port over the limited `chrono` functionality in this repository to use the pre-existing transitive `time` dependency from `x509-parser` instead.

I admit to not testing this code, but a look at the documentation, source code of both of these libraries, and running some `cargo check` to ensure this still compiles I believe the changes here are correct.