### PR TITLE
Update base64 and x509-parser dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ serde_json = "1.0.81"
 serde = { version = "1.0.137", features=["derive"] }
 ring = { version = "0.17.7", features = ["std"], optional = true }
 aws-lc-rs = { version = "1.5.2", optional = true, default-features = false, features = ["aws-lc-sys"] }
-base64 = "0.21.7"
+base64 = "0.22.0"
 log = "0.4.17"
 webpki-roots = "0.26"
 pem = "3.0.3"
 thiserror = "1.0.31"
-x509-parser = "0.15.1"
+x509-parser = "0.16.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 async-trait = "0.1.53"
 async-io = "2.3.0"
@@ -36,7 +36,7 @@ blocking = "1.4.1"
 
 [dev-dependencies]
 simple_logger = "4.3.3"
-clap = { version = "3.1.18", features = ["derive"] }
+clap = { version = "4.5.4", features = ["derive"] }
 axum = "0.7"
 tokio = { version="1.35.1", features = ["full"] }
 tokio-stream = { version="0.1.14", features = ["net"] }

--- a/examples/high_level.rs
+++ b/examples/high_level.rs
@@ -19,7 +19,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment

--- a/examples/high_level_tokio.rs
+++ b/examples/high_level_tokio.rs
@@ -18,7 +18,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment

--- a/examples/high_level_warp.rs
+++ b/examples/high_level_warp.rs
@@ -17,7 +17,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment

--- a/examples/low_level.rs
+++ b/examples/low_level.rs
@@ -21,7 +21,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment

--- a/examples/low_level_axum.rs
+++ b/examples/low_level_axum.rs
@@ -17,7 +17,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment

--- a/examples/low_level_tokio.rs
+++ b/examples/low_level_tokio.rs
@@ -18,7 +18,7 @@ struct Args {
     email: Vec<String>,
 
     /// Cache directory
-    #[clap(short, parse(from_os_str))]
+    #[clap(short, value_parser)]
     cache: Option<PathBuf>,
 
     /// Use Let's Encrypt production environment


### PR DESCRIPTION
Updated a few deps to get rid of the duplicate versions of syn and base64 crates. (Trying to reduce build times in my app)

## Before
```nushell
❯ cargo tree --duplicate --edges no-dev --depth 0
base64 v0.21.7
base64 v0.22.0
event-listener v3.1.0
event-listener v4.0.3
event-listener-strategy v0.3.0
event-listener-strategy v0.4.0
syn v1.0.109
syn v2.0.59
```
## After
```nushell
❯ cargo tree --duplicate --edges no-dev --depth 0
event-listener v3.1.0 
event-listener v4.0.3
event-listener-strategy v0.3.0 
event-listener-strategy v0.4.0 
```

Several other dependencies have new versions but will require rustls 0.26 which we can't use until https://github.com/FlorianUekermann/async-web-client/pull/12 is merged. I'm happy to help there if the author doesn't respond.

Thanks for making and maintaining this crate!