### PR TITLE
Update axum-server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = "0.1.53"
 async-io = "2.3.0"
 tokio = { version= "1.20.1", optional= true }
 tokio-util = { version="0.7.3", features = ["compat"], optional=true }
-axum-server = { version = "0.6", features = ["tls-rustls"], optional=true }
+axum-server = { version = "0.7", features = ["tls-rustls-no-provider"], optional=true }
 async-web-client = { version = "0.6.2", default-features = false }
 http = "1"
 blocking = "1.4.1"


### PR DESCRIPTION
Updates axum-server to the latest version.

From my understanding, if you don't have something else depending on rustls  you may need to add one of these to your project's cargo.toml:
```toml
# Default features enables the "aws_lc_rs" feature. 
# This currently has additional build dependencies on Windows though. See https://github.com/aws/aws-lc-rs/issues/364
rustls = "0.23.12"
```
**OR**
 
```toml
# Use the "ring" provider instead of the default "aws_lc_rs" provider
rustls = {version = "0.23.12", default-features=false,  features = ["ring"]}
```

Because of this, this might be considered a breaking change (not sure though tbh). Let me know if you want me to update version numbers or anything, I left that alone so it could be handled however you want.