### PR TITLE
Update rust.yml to install rustfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup component add clippy
+      - run: rustup component add rustfmt
       - run: cargo fmt --check
       - run: cargo build --verbose --no-default-features --features ${{ matrix.crypto }},${{ matrix.tokio }}
       - run: cargo test --verbose --no-default-features --features ${{ matrix.crypto }},${{ matrix.tokio }}


### PR DESCRIPTION
The ci errors indicate that the toolchain installation doesn't install rustfmt. This installs it just before it is invoked.