### PR TITLE
Http-01 Challenge Framework support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ hyper = "1.3.1"
 http-body-util = "0.1.1"
 bytes = "1.6.0"
 hyper-util = "0.1.3"
-axum-macros = "0.5.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"], optional
 async-web-client = { version = "0.6.2", default-features = false }
 http = "1"
 blocking = "1.4.1"
+fastcache = "0.1.7"
 
 [dev-dependencies]
 simple_logger = "4.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,12 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"], optional
 async-web-client = { version = "0.6.2", default-features = false }
 http = "1"
 blocking = "1.4.1"
+tower-service = { version = "0.3.3",  optional=true }
 
 [dev-dependencies]
 simple_logger = "4.3.3"
 clap = { version = "3.1.18", features = ["derive"] }
-axum = "0.7"
+axum = "0.8"
 tokio = { version="1.35.1", features = ["full"] }
 tokio-stream = { version="0.1.14", features = ["net"] }
 tokio-util = { version="0.7.10", features = ["compat"] }
@@ -60,7 +61,8 @@ rustdoc-args = ["--cfg", "doc_auto_cfg"]
 default = ["aws-lc-rs", "tls12"]
 ring = ["dep:ring", "async-web-client/ring", "rcgen/ring"]
 aws-lc-rs = ["dep:aws-lc-rs", "async-web-client/aws-lc-rs", "rcgen/aws_lc_rs"]
-axum = ["dep:axum-server", "tokio"]
+axum = ["dep:axum-server", "tower"]
+tower = ["dep:tower-service", "tokio"]
 tokio = ["dep:tokio", "dep:tokio-util"]
 tls12 = ["async-web-client/tls12"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ required-features = ["axum"]
 
 [[example]]
 name = "low_level_axum_http"
-required-features = ["axum"]
+required-features = ["axum", "tower"]
 
 [[example]]
 name="high_level_warp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ hyper = "1.3.1"
 http-body-util = "0.1.1"
 bytes = "1.6.0"
 hyper-util = "0.1.3"
+axum-macros = "0.5.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -64,8 +65,12 @@ tokio = ["dep:tokio", "dep:tokio-util"]
 tls12 = ["async-web-client/tls12"]
 
 [[example]]
-name="low_level_axum"
-required-features=["axum"]
+name = "low_level_axum"
+required-features = ["axum"]
+
+[[example]]
+name = "low_level_axum_http"
+required-features = ["axum"]
 
 [[example]]
 name="high_level_warp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ axum-server = { version = "0.7", features = ["tls-rustls-no-provider"], optional
 async-web-client = { version = "0.6.2", default-features = false }
 http = "1"
 blocking = "1.4.1"
-fastcache = "0.1.7"
 
 [dev-dependencies]
 simple_logger = "4.3.3"

--- a/examples/low_level_axum_http.rs
+++ b/examples/low_level_axum_http.rs
@@ -74,7 +74,7 @@ async fn challenge_http_app(http_challenge_app: Router) {
 }
 
 async fn http01_challenge(State(resolver): State<Arc<ResolvesServerCertAcme>>, Path(challenge_token): Path<String>) -> Response {
-    match resolver.get_key_auth(&challenge_token) {
+    match resolver.get_http_01_key_auth(&challenge_token) {
         None => (StatusCode::NOT_FOUND,).into_response(),
         Some(key_auth) => (
             StatusCode::OK,

--- a/examples/low_level_axum_http.rs
+++ b/examples/low_level_axum_http.rs
@@ -73,22 +73,14 @@ async fn challenge_http_app(http_challenge_app: Router) {
     axum::serve(listener, http_challenge_app.into_make_service()).await.unwrap();
 }
 
-#[debug_handler]
 async fn http01_challenge(State(resolver): State<Arc<ResolvesServerCertAcme>>, Path(challenge_token): Path<String>) -> Response {
     match resolver.get_key_auth(&challenge_token) {
         None => (StatusCode::NOT_FOUND,).into_response(),
-        Some(key_auth) => {
-            if key_auth.is_ascii() {
-                (
-                    StatusCode::OK,
-                    [(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"))],
-                    String::from_utf8(key_auth.as_ref().clone()).unwrap(),
-                )
-                    .into_response()
-            } else {
-                log::debug!("Key_auth is not ascii");
-                (StatusCode::NOT_FOUND,).into_response()
-            }
-        }
+        Some(key_auth) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"))],
+            key_auth,
+        )
+            .into_response(),
     }
 }

--- a/examples/low_level_axum_http.rs
+++ b/examples/low_level_axum_http.rs
@@ -1,7 +1,6 @@
 use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 use axum::{routing::get, Router};
-use axum_macros::debug_handler;
 use axum_server::bind;
 use clap::Parser;
 use http::{header, HeaderValue, StatusCode};

--- a/examples/low_level_axum_http.rs
+++ b/examples/low_level_axum_http.rs
@@ -1,0 +1,94 @@
+use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
+use axum::{routing::get, Router};
+use axum_macros::debug_handler;
+use axum_server::bind;
+use clap::Parser;
+use http::{header, HeaderValue, StatusCode};
+use rustls_acme::caches::DirCache;
+use rustls_acme::UseChallenge::Http01;
+use rustls_acme::{AcmeConfig, ResolvesServerCertAcme};
+use std::net::{Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio_stream::StreamExt;
+
+#[derive(Parser, Debug)]
+struct Args {
+    /// Domains
+    #[clap(short, required = true)]
+    domains: Vec<String>,
+
+    /// Contact info
+    #[clap(short)]
+    email: Vec<String>,
+
+    /// Cache directory
+    #[clap(short, parse(from_os_str))]
+    cache: Option<PathBuf>,
+
+    /// Use Let's Encrypt production environment
+    /// (see https://letsencrypt.org/docs/staging-environment/)
+    #[clap(long)]
+    prod: bool,
+
+    #[clap(short, long, default_value = "443")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() {
+    simple_logger::init_with_level(log::Level::Info).unwrap();
+    let args = Args::parse();
+
+    let mut state = AcmeConfig::new(args.domains)
+        .contact(args.email.iter().map(|e| format!("mailto:{}", e)))
+        .cache_option(args.cache.clone().map(DirCache::new))
+        .directory_lets_encrypt(args.prod)
+        .challenge_type(Http01)
+        .state();
+    let acceptor = state.axum_acceptor(state.default_rustls_config());
+
+    let http_challenge_app = Router::new()
+        .route("/.well-known/acme-challenge/{challenge_token}/", get(http01_challenge))
+        .with_state(state.resolver().clone());
+    tokio::spawn(challenge_http_app(http_challenge_app));
+
+    tokio::spawn(async move {
+        loop {
+            match state.next().await.unwrap() {
+                Ok(ok) => log::info!("event: {:?}", ok),
+                Err(err) => log::error!("error: {:?}", err),
+            }
+        }
+    });
+
+    let app = Router::new().route("/", get(|| async { "Hello Tls!" }));
+    let addr = SocketAddr::from((Ipv6Addr::UNSPECIFIED, args.port));
+    bind(addr).acceptor(acceptor).serve(app.into_make_service()).await.unwrap();
+}
+
+async fn challenge_http_app(http_challenge_app: Router) {
+    let listener = tokio::net::TcpListener::bind((Ipv6Addr::UNSPECIFIED, 80)).await.unwrap();
+    axum::serve(listener, http_challenge_app.into_make_service()).await.unwrap();
+}
+
+#[debug_handler]
+async fn http01_challenge(State(resolver): State<Arc<ResolvesServerCertAcme>>, Path(challenge_token): Path<String>) -> Response {
+    match resolver.get_key_auth(&challenge_token) {
+        None => (StatusCode::NOT_FOUND,).into_response(),
+        Some(key_auth) => {
+            if key_auth.is_ascii() {
+                (
+                    StatusCode::OK,
+                    [(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"))],
+                    String::from_utf8(key_auth.as_ref().clone()).unwrap(),
+                )
+                    .into_response()
+            } else {
+                log::debug!("Key_auth is not ascii");
+                (StatusCode::NOT_FOUND,).into_response()
+            }
+        }
+    }
+}

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -1,11 +1,10 @@
-use std::sync::Arc;
-use aws_lc_rs::digest::Digest;
 use crate::any_ecdsa_type;
 use crate::crypto::error::{KeyRejected, Unspecified};
 use crate::crypto::rand::SystemRandom;
 use crate::crypto::signature::{EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING};
 use crate::https_helper::{https, HttpsRequestError};
 use crate::jose::{key_authorization_sha256, sign, JoseError};
+use aws_lc_rs::digest::Digest;
 use base64::prelude::*;
 use futures_rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
 use futures_rustls::rustls::{sign::CertifiedKey, ClientConfig};
@@ -14,6 +13,7 @@ use http::{Method, Response};
 use rcgen::{CustomExtension, KeyPair, PKCS_ECDSA_P256_SHA256};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::sync::Arc;
 use thiserror::Error;
 
 pub const LETS_ENCRYPT_STAGING_DIRECTORY: &str = "https://acme-staging-v02.api.letsencrypt.org/directory";

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,10 +22,13 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) domains: Vec<String>,
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
-    pub(crate) challenge_type: UseChallenge
+    pub(crate) challenge_type: UseChallenge,
 }
 
-pub enum UseChallenge { Http01, TlsAlpn01 }
+pub enum UseChallenge {
+    Http01,
+    TlsAlpn01,
+}
 
 impl AcmeConfig<Infallible, Infallible> {
     /// Creates a new [AcmeConfig] instance.
@@ -82,7 +85,7 @@ impl AcmeConfig<Infallible, Infallible> {
             domains: domains.into_iter().map(|s| s.as_ref().into()).collect(),
             contact: vec![],
             cache: Box::new(NoCache::default()),
-            challenge_type: TlsAlpn01
+            challenge_type: TlsAlpn01,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::acme::{LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
 use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
+use crate::UseChallenge::TlsAlpn01;
 use crate::{crypto_provider, AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
 use core::fmt;
@@ -21,7 +22,10 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) domains: Vec<String>,
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
+    pub(crate) challenge_type: UseChallenge
 }
+
+pub enum UseChallenge { Http01, TlsAlpn01 }
 
 impl AcmeConfig<Infallible, Infallible> {
     /// Creates a new [AcmeConfig] instance.
@@ -78,6 +82,7 @@ impl AcmeConfig<Infallible, Infallible> {
             domains: domains.into_iter().map(|s| s.as_ref().into()).collect(),
             contact: vec![],
             cache: Box::new(NoCache::default()),
+            challenge_type: TlsAlpn01
         }
     }
 }
@@ -132,6 +137,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             domains: self.domains,
             contact: self.contact,
             cache: Box::new(cache),
+            challenge_type: self.challenge_type,
         }
     }
     pub fn cache_compose<CC: 'static + CertCache, CA: 'static + AccountCache>(self, cert_cache: CC, account_cache: CA) -> AcmeConfig<CC::EC, CA::EA> {
@@ -145,6 +151,10 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             Some(cache) => self.cache(cache),
             None => self.cache(NoCache::<C::EC, C::EA>::default()),
         }
+    }
+    pub fn challenge_type(mut self, challenge_type: UseChallenge) -> Self {
+        self.challenge_type = challenge_type;
+        self
     }
     pub fn state(self) -> AcmeState<EC, EA> {
         AcmeState::new(self)

--- a/src/jose.rs
+++ b/src/jose.rs
@@ -23,9 +23,13 @@ pub(crate) fn sign(key: &EcdsaKeyPair, kid: Option<&str>, nonce: String, url: &s
     Ok(serde_json::to_string(&body)?)
 }
 
-pub(crate) fn key_authorization_sha256(key: &EcdsaKeyPair, token: &str) -> Result<Digest, JoseError> {
+pub(crate) fn key_authorization(key: &EcdsaKeyPair, token: &str) -> Result<String, JoseError> {
     let jwk = Jwk::new(key);
-    let key_authorization = format!("{}.{}", token, jwk.thumb_sha256_base64()?);
+    Ok(format!("{}.{}", token, jwk.thumb_sha256_base64()?))
+}
+
+pub(crate) fn key_authorization_sha256(key: &EcdsaKeyPair, token: &str) -> Result<Digest, JoseError> {
+    let key_authorization = key_authorization(key, token)?;
     Ok(digest(&SHA256, key_authorization.as_bytes()))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,8 @@ mod resolver;
 mod state;
 #[cfg(feature = "tokio")]
 pub mod tokio;
+#[cfg(feature = "tower")]
+pub mod tower;
 
 pub use futures_rustls;
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -45,7 +45,7 @@ impl ResolvesServerCertAcme {
     pub(crate) fn clear_challenge_data(&self) {
         self.inner.lock().unwrap().challenge_data = None;
     }
-    pub fn get_key_auth(&self, challenge_token: &String) -> Option<String> {
+    pub fn get_http_01_key_auth(&self, challenge_token: &str) -> Option<String> {
         match &self.inner.lock().unwrap().challenge_data {
             Some(ChallengeData::Http01 { token, key_auth }) => {
                 if token.eq(challenge_token) {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -21,7 +21,7 @@ struct Inner {
 #[derive(Debug)]
 enum ChallengeData {
     TlsAlpn01 { sni: String, cert: Arc<CertifiedKey> },
-    Http01 { token: String, key_auth: Arc<Vec<u8>> },
+    Http01 { token: String, key_auth: String },
 }
 
 impl ResolvesServerCertAcme {
@@ -39,13 +39,13 @@ impl ResolvesServerCertAcme {
     pub(crate) fn set_tls_alpn_01_challenge_data(&self, domain: String, cert: Arc<CertifiedKey>) {
         self.inner.lock().unwrap().challenge_data = Some(ChallengeData::TlsAlpn01 { sni: domain, cert });
     }
-    pub(crate) fn set_http_01_challenge_data(&self, token: String, key_auth: Arc<Vec<u8>>) {
+    pub(crate) fn set_http_01_challenge_data(&self, token: String, key_auth: String) {
         self.inner.lock().unwrap().challenge_data = Some(ChallengeData::Http01 { token, key_auth })
     }
     pub(crate) fn clear_challenge_data(&self) {
         self.inner.lock().unwrap().challenge_data = None;
     }
-    pub fn get_key_auth(&self, challenge_token: &String) -> Option<Arc<Vec<u8>>> {
+    pub fn get_key_auth(&self, challenge_token: &String) -> Option<String> {
         match &self.inner.lock().unwrap().challenge_data {
             Some(ChallengeData::Http01 { token, key_auth }) => {
                 if token.eq(challenge_token) {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,13 +1,11 @@
-use fastcache::Cache;
 use futures_rustls::rustls::{
     server::{ClientHello, ResolvesServerCert},
     sign::CertifiedKey,
 };
 use std::collections::BTreeMap;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
 use crate::is_tls_alpn_challenge;
 
 #[derive(Debug)]
@@ -15,21 +13,11 @@ pub struct ResolvesServerCertAcme {
     inner: Mutex<Inner>,
 }
 
+#[derive(Debug)]
 struct Inner {
     cert: Option<Arc<CertifiedKey>>,
     auth_keys: BTreeMap<String, Arc<CertifiedKey>>,
-    key_auths: Cache<String, Arc<Vec<u8>>>,
-}
-
-impl Debug for Inner {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter) -> ::core::fmt::Result {
-        f.debug_struct("Inner")
-            .field("cert", &self.cert)
-            .field("auth_keys", &self.auth_keys)
-            //ignore non printable fashcache
-            .finish()
-    }
+    key_auths: BTreeMap<String, Arc<Vec<u8>>>,
 }
 
 impl ResolvesServerCertAcme {
@@ -39,7 +27,7 @@ impl ResolvesServerCertAcme {
                 cert: None,
                 auth_keys: Default::default(),
                 // Reasonably high key auth cache defaults. Avoid Infinite accumulation
-                key_auths: Cache::new(500, Duration::from_secs(3600)),
+                key_auths: Default::default(),
             }),
         })
     }
@@ -52,13 +40,11 @@ impl ResolvesServerCertAcme {
     pub(crate) fn set_key_auth(&self, token: String, key_auth: Arc<Vec<u8>>) {
         self.inner.lock().unwrap().key_auths.insert(token, key_auth);
     }
+    pub (crate) fn clear_key_auth(&self, token: &String) {
+        self.inner.lock().unwrap().key_auths.remove(token);
+    }
     pub fn get_key_auth(&self, token: &String) -> Option<Arc<Vec<u8>>> {
-        match self.inner.lock().unwrap().key_auths.get(token) {
-            None => None,
-            Some(key_auth) => {
-                Some(key_auth.get().clone())
-            }
-        }
+        self.inner.lock().unwrap().key_auths.get(token).cloned()
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -48,7 +48,7 @@ impl ResolvesServerCertAcme {
     pub fn get_http_01_key_auth(&self, challenge_token: &str) -> Option<String> {
         match &self.inner.lock().unwrap().challenge_data {
             Some(ChallengeData::Http01 { token, key_auth }) => {
-                if token.eq(challenge_token) {
+                if token == challenge_token {
                     Some(key_auth.clone())
                 } else {
                     None
@@ -68,20 +68,16 @@ impl ResolvesServerCert for ResolvesServerCertAcme {
                     log::debug!("client did not supply SNI");
                     None
                 }
-                Some(domain) => {
-                    let domain = domain.to_owned();
-                    let domain: String = AsRef::<str>::as_ref(&domain).into();
-                    match &self.inner.lock().unwrap().challenge_data {
-                        Some(ChallengeData::TlsAlpn01 { sni, cert }) => {
-                            if domain.eq(sni) {
-                                Some(cert.clone())
-                            } else {
-                                None
-                            }
+                Some(domain) => match &self.inner.lock().unwrap().challenge_data {
+                    Some(ChallengeData::TlsAlpn01 { sni, cert }) => {
+                        if sni == domain {
+                            Some(cert.clone())
+                        } else {
+                            None
                         }
-                        _ => None,
                     }
-                }
+                    _ => None,
+                },
             }
         } else {
             self.inner.lock().unwrap().cert.clone()

--- a/src/state.rs
+++ b/src/state.rs
@@ -300,7 +300,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 let challenge = match config.challenge_type {
                     UseChallenge::Http01 => {
                         let (challenge, key_auth) = account.http_01(&auth.challenges)?;
-                        resolver.set_http_01_challenge_data(challenge.token.clone(), Arc::new(Vec::from(key_auth.as_ref())));
+                        resolver.set_http_01_challenge_data(challenge.token.clone(), key_auth);
                         challenge
                     }
                     UseChallenge::TlsAlpn01 => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -136,6 +136,12 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         #[allow(deprecated)]
         crate::axum::AxumAcceptor::new(self.acceptor(), rustls_config)
     }
+
+    #[cfg(feature = "tower")]
+    pub fn http01_challenge_tower_service(&self) -> crate::tower::TowerHttp01ChallengeService {
+        crate::tower::TowerHttp01ChallengeService(self.resolver.clone())
+    }
+
     pub fn resolver(&self) -> Arc<ResolvesServerCertAcme> {
         self.resolver.clone()
     }

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+use http::{header, HeaderValue, Request, StatusCode};
+use crate::ResolvesServerCertAcme;
+
+#[derive(Clone)]
+pub struct TowerHttp01ChallengeService(pub(crate) Arc<ResolvesServerCertAcme>);
+
+impl<B> tower_service::Service<Request<B>> for TowerHttp01ChallengeService {
+    type Response = http::Response<String>;
+    type Error = std::convert::Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let mut response = http::Response::new(String::new());
+        *response.status_mut() = StatusCode::NOT_FOUND;
+        let Some((_, token)) = req.uri().path().rsplit_once('/') else {
+            return std::future::ready(Ok(response))
+        };
+        let Some(body) = self.0.get_http_01_key_auth(&token) else {
+            return std::future::ready(Ok(response))
+        };
+        *response.status_mut() = StatusCode::OK;
+        *response.body_mut() = body;
+        response.headers_mut().append(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"));
+        std::future::ready(Ok(response))
+    }
+}

--- a/src/tower.rs
+++ b/src/tower.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
-use http::{header, HeaderValue, Request, StatusCode};
 use crate::ResolvesServerCertAcme;
+use http::{header, HeaderValue, Request, StatusCode};
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct TowerHttp01ChallengeService(pub(crate) Arc<ResolvesServerCertAcme>);
@@ -18,14 +18,16 @@ impl<B> tower_service::Service<Request<B>> for TowerHttp01ChallengeService {
         let mut response = http::Response::new(String::new());
         *response.status_mut() = StatusCode::NOT_FOUND;
         let Some((_, token)) = req.uri().path().rsplit_once('/') else {
-            return std::future::ready(Ok(response))
+            return std::future::ready(Ok(response));
         };
         let Some(body) = self.0.get_http_01_key_auth(&token) else {
-            return std::future::ready(Ok(response))
+            return std::future::ready(Ok(response));
         };
         *response.status_mut() = StatusCode::OK;
         *response.body_mut() = body;
-        response.headers_mut().append(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"));
+        response
+            .headers_mut()
+            .append(header::CONTENT_TYPE, HeaderValue::from_static("application/octet-stream"));
         std::future::ready(Ok(response))
     }
 }


### PR DESCRIPTION
Approach to the implementation of support challenge type https://datatracker.ietf.org/doc/html/rfc8555#section-8.3.

Approach:
- New option configuration value that allows the developer to decide which challenge type they wish to use. Defaults to `TlsAlpn01`
- ~Cache of fixed reasonable size and duration that can map the token that will come from the challenge to the key_authorization that is needed to be returned from the resource `/.well-known/acme-challenge/{token}` in format 
`ASCII representation of the key authorization`. The cache is intended to guard against a growing number of tokens accumulating over many recertification cycles~
- ~Populate a map from the token to the key auth. only expose through key get enforce developer gets token from request. Clean up the map when authorization is successful or fails.~
- populate a challenge data field in the resolver that is cleared up on valid or invalid auth.  

Alternate approaches considered:
- Store key auth map outside of resolver. Unclear if semantically it belongs in same inner/mutex
- ~Don't use cache dependency, roll own, clean up inside main state future loop to guard against infinite accumulation~

Open questions:
- Best way to test. Unclear of good boundaries. Can volunteer personal site and test via local build. 
- Do we ever need to store more than one key auth at a time. Is it even possible to have multiple challenges and tokens running at once?