### PR TITLE
fix: patch rcgen-0.13.3

### DIFF
--- a/src/caches/test.rs
+++ b/src/caches/test.rs
@@ -68,7 +68,7 @@ impl<EC: Debug, EA: Debug> CertCache for TestCache<EC, EA> {
         params.not_before = date_time_ymd(2000, 1, 1);
         params.not_after = date_time_ymd(3000, 1, 1);
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-        let cert = params.signed_by(&key_pair, &self.ca_cert, &self.ca_key).unwrap();
+        let cert = params.signed_by(&key_pair, &*self.ca_cert, &self.ca_key).unwrap();
         let private_key_pem = key_pair.serialize_pem();
         let signed_cert_pem = cert.pem();
         Ok(Some([&private_key_pem, "\n", &signed_cert_pem, "\n", &self.ca_pem].concat().into_bytes()))


### PR DESCRIPTION
Hi! Since the upsate of `rcgen`-0.13.3, the test fails as reported in #73.

The reason is that the signature of `signed_by` is changed from `Certificate` to `AsRef<CertificateParams>`, and that `self.ca_cert` is `Arc`-ed in `TestCache`.

https://github.com/FlorianUekermann/rustls-acme/blob/a02f1b940bdf9a3f8ae1a9034c1c59b69466437d/src/caches/test.rs#L71

So the solution is to simply `deref` the object. This PR simply solves the compilation error of the test code.