### PR TITLE
feat: add 6-days-long and IP address certificates

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -85,7 +85,16 @@ impl Account {
         Ok((location, body))
     }
     pub async fn new_order(&self, client_config: &Arc<ClientConfig>, domains: Vec<String>) -> Result<(String, Order), AcmeError> {
-        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::Dns).collect();
+        let domains: Vec<Identifier> = domains
+            .into_iter()
+            .map(|s| {
+                if s.parse::<std::net::IpAddr>().is_ok() {
+                    Identifier::Ip(s)
+                } else {
+                    Identifier::Dns(s)
+                }
+            })
+            .collect();
         let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
         let response = self.request(client_config, &self.directory.new_order, &payload).await?;
         let url = response.0.ok_or(AcmeError::MissingHeader("Location"))?;
@@ -214,6 +223,16 @@ pub enum AuthStatus {
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Identifier {
     Dns(String),
+    Ip(String),
+}
+
+impl Identifier {
+    pub fn into_inner(self) -> String {
+        match self {
+            Identifier::Dns(s) => s,
+            Identifier::Ip(s) => s,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -85,17 +85,28 @@ impl Account {
         Ok((location, body))
     }
     pub async fn new_order(&self, client_config: &Arc<ClientConfig>, domains: Vec<String>) -> Result<(String, Order), AcmeError> {
+        let mut has_ip = false;
         let domains: Vec<Identifier> = domains
             .into_iter()
             .map(|s| {
                 if s.parse::<std::net::IpAddr>().is_ok() {
+                    has_ip = true;
                     Identifier::Ip(s)
                 } else {
                     Identifier::Dns(s)
                 }
             })
             .collect();
-        let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
+        let payload = if has_ip {
+            serde_json::to_string(&serde_json::json!({
+                "identifiers": domains,
+                "profile": "shortlived"
+            }))?
+        } else {
+            serde_json::to_string(&serde_json::json!({
+                "identifiers": domains
+            }))?
+        };
         let response = self.request(client_config, &self.directory.new_order, &payload).await?;
         let url = response.0.ok_or(AcmeError::MissingHeader("Location"))?;
         let order = serde_json::from_str(&response.1)?;

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -85,8 +85,28 @@ impl Account {
         Ok((location, body))
     }
     pub async fn new_order(&self, client_config: &Arc<ClientConfig>, domains: Vec<String>) -> Result<(String, Order), AcmeError> {
-        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::Dns).collect();
-        let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
+        let mut has_ip = false;
+        let domains: Vec<Identifier> = domains
+            .into_iter()
+            .map(|s| {
+                if let Ok(addr) = s.parse::<std::net::IpAddr>() {
+                    has_ip = true;
+                    Identifier::Ip(addr)
+                } else {
+                    Identifier::Dns(s)
+                }
+            })
+            .collect();
+        let payload = if has_ip {
+            serde_json::to_string(&serde_json::json!({
+                "identifiers": domains,
+                "profile": "shortlived"
+            }))?
+        } else {
+            serde_json::to_string(&serde_json::json!({
+                "identifiers": domains
+            }))?
+        };
         let response = self.request(client_config, &self.directory.new_order, &payload).await?;
         let url = response.0.ok_or(AcmeError::MissingHeader("Location"))?;
         let order = serde_json::from_str(&response.1)?;
@@ -214,6 +234,39 @@ pub enum AuthStatus {
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Identifier {
     Dns(String),
+    Ip(std::net::IpAddr),
+}
+
+impl Identifier {
+    pub fn into_inner(self) -> String {
+        match self {
+            Identifier::Dns(s) => s,
+            Identifier::Ip(addr) => addr.to_string(),
+        }
+    }
+
+    /// Returns `true` if this identifier is an IP address.
+    pub fn is_ip(&self) -> bool {
+        matches!(self, Identifier::Ip(_))
+    }
+}
+
+impl From<std::net::IpAddr> for Identifier {
+    fn from(addr: std::net::IpAddr) -> Self {
+        Identifier::Ip(addr)
+    }
+}
+
+impl From<String> for Identifier {
+    fn from(s: String) -> Self {
+        Identifier::Dns(s)
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(s: &str) -> Self {
+        Identifier::Dns(s.to_owned())
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -270,5 +323,41 @@ fn get_header(response: &Response<String>, header: &'static str) -> Result<Strin
     match response.headers().get_all(header).iter().next_back() {
         None => Err(AcmeError::MissingHeader(header)),
         Some(value) => Ok(value.to_str()?.to_string()),
+    }
+}
+
+/// Convert an IP address to the reverse-DNS (ARPA) format used for TLS-ALPN-01 challenge SNI.
+///
+/// Per RFC 8738 §6, since RFC 6066 does not permit IP addresses in the SNI HostName field,
+/// the server MUST use the IN-ADDR.ARPA or IP6.ARPA reverse mapping instead.
+///
+/// # Examples
+///
+/// ```
+/// use rustls_acme::acme::ip_to_arpa;
+/// use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+///
+/// assert_eq!(
+///     ip_to_arpa(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
+///     "1.2.0.192.in-addr.arpa"
+/// );
+/// assert_eq!(
+///     ip_to_arpa(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+///     "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa"
+/// );
+/// ```
+pub fn ip_to_arpa(addr: std::net::IpAddr) -> String {
+    match addr {
+        std::net::IpAddr::V4(v4) => {
+            let o = v4.octets();
+            format!("{}.{}.{}.{}.in-addr.arpa", o[3], o[2], o[1], o[0])
+        }
+        std::net::IpAddr::V6(v6) => {
+            let o = v6.octets();
+            let hex: String = o.iter().map(|&b| format!("{:02x}", b)).collect();
+            let labels: String = hex.chars().rev().map(|c| format!("{c}.")).collect();
+            // remove trailing dot, add ip6.arpa suffix
+            labels.trim_end_matches('.').to_owned() + ".ip6.arpa"
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::acme::{LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
+use crate::acme::{Identifier, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
 use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
 use crate::UseChallenge::TlsAlpn01;
 use crate::{crypto_provider, AccountCache, Cache, CertCache};
@@ -10,6 +10,7 @@ use futures_rustls::rustls::crypto::CryptoProvider;
 use futures_rustls::rustls::{ClientConfig, RootCertStore};
 use std::convert::Infallible;
 use std::fmt::Debug;
+use std::net::IpAddr;
 use std::sync::Arc;
 
 /// Configuration for an ACME resolver.
@@ -19,6 +20,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) client_config: Arc<ClientConfig>,
     pub(crate) directory_url: String,
     pub(crate) domains: Vec<String>,
+    pub(crate) ips: Vec<IpAddr>,
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
     pub(crate) challenge_type: UseChallenge,
@@ -56,13 +58,13 @@ impl AcmeConfig<Infallible, Infallible> {
     /// let config: AcmeConfig<EC, EA> = AcmeConfig::new(["example.com"]).cache(NoCache::default());
     /// ```
     #[cfg(all(feature = "webpki-roots", any(feature = "ring", feature = "aws-lc-rs")))]
-    pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
-        Self::new_with_provider(domains, crypto_provider().into())
+    pub fn new(identifiers: impl IntoIterator<Item = impl Into<Identifier>>) -> Self {
+        Self::new_with_provider(identifiers, crypto_provider().into())
     }
 
     /// Same as [AcmeConfig::new], with a specific [CryptoProvider].
     #[cfg(feature = "webpki-roots")]
-    pub fn new_with_provider(domains: impl IntoIterator<Item = impl AsRef<str>>, provider: Arc<CryptoProvider>) -> Self {
+    pub fn new_with_provider(identifiers: impl IntoIterator<Item = impl Into<Identifier>>, provider: Arc<CryptoProvider>) -> Self {
         let mut root_store = RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             let ta = ta.to_owned();
@@ -79,10 +81,12 @@ impl AcmeConfig<Infallible, Infallible> {
                 .with_root_certificates(root_store)
                 .with_no_client_auth(),
         );
+        let (domains, ips) = extract_from_identifiers(identifiers);
         AcmeConfig {
             client_config,
             directory_url: LETS_ENCRYPT_STAGING_DIRECTORY.into(),
-            domains: domains.into_iter().map(|s| s.as_ref().into()).collect(),
+            domains,
+            ips,
             contact: vec![],
             cache: Box::new(NoCache::default()),
             challenge_type: TlsAlpn01,
@@ -132,11 +136,13 @@ impl AcmeConfig<Infallible, Infallible> {
     ///     .cache(NoCache::default());
     /// # }
     /// ```
-    pub fn new_with_client_config(domains: impl IntoIterator<Item = impl AsRef<str>>, client_config: Arc<ClientConfig>) -> Self {
+    pub fn new_with_client_config(identifiers: impl IntoIterator<Item = impl Into<Identifier>>, client_config: Arc<ClientConfig>) -> Self {
+        let (domains, ips) = extract_from_identifiers(identifiers);
         AcmeConfig {
             client_config,
             directory_url: LETS_ENCRYPT_STAGING_DIRECTORY.into(),
-            domains: domains.into_iter().map(|s| s.as_ref().into()).collect(),
+            domains,
+            ips,
             contact: vec![],
             cache: Box::new(NoCache::default()),
             challenge_type: TlsAlpn01,
@@ -171,6 +177,26 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
         self
     }
 
+    /// Add IP addresses to the certificate. IP identifiers will use Let's Encrypt's
+    /// shortlived profile and produce nonce-extended duration certificates (6 days).
+    pub fn ips(mut self, ips: impl IntoIterator<Item = IpAddr>) -> Self {
+        self.ips.extend(ips);
+        self
+    }
+
+    /// Add a single IP address to the certificate.
+    pub fn ips_push(mut self, ip: IpAddr) -> Self {
+        self.ips.push(ip);
+        self
+    }
+
+    /// Return all identifiers (domains + IP strings) as a combined list.
+    pub(crate) fn all_domains(&self) -> Vec<String> {
+        let mut all = self.domains.clone();
+        all.extend(self.ips.iter().map(|ip| ip.to_string()));
+        all
+    }
+
     /// Provide a list of contacts for the account.
     ///
     /// Note that email addresses must include a `mailto:` prefix.
@@ -192,6 +218,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             client_config: self.client_config,
             directory_url: self.directory_url,
             domains: self.domains,
+            ips: self.ips,
             contact: self.contact,
             cache: Box::new(cache),
             challenge_type: self.challenge_type,
@@ -247,11 +274,25 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
     }
 }
 
+fn extract_from_identifiers(identifiers: impl IntoIterator<Item = impl Into<Identifier>>) -> (Vec<String>, Vec<IpAddr>) {
+    let identifiers: Vec<Identifier> = identifiers.into_iter().map(Into::into).collect();
+    let mut domains = Vec::new();
+    let mut ips = Vec::new();
+    for id in identifiers {
+        match id {
+            Identifier::Dns(s) => domains.push(s),
+            Identifier::Ip(addr) => ips.push(addr),
+        }
+    }
+    (domains, ips)
+}
+
 impl<EC: 'static + Debug, EA: 'static + Debug> fmt::Debug for AcmeConfig<EC, EA> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AcmeConfig")
             .field("directory", &self.directory_url)
             .field("domains", &self.domains)
+            .field("ips", &self.ips)
             .field("contact", &self.contact)
             .finish_non_exhaustive()
     }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -66,7 +66,17 @@ impl ResolvesServerCert for ResolvesServerCertAcme {
             match client_hello.server_name() {
                 None => {
                     log::debug!("client did not supply SNI");
-                    None
+                    match &self.inner.lock().unwrap().challenge_data {
+                        Some(ChallengeData::TlsAlpn01 { sni, cert }) => {
+                            if sni.parse::<std::net::IpAddr>().is_ok() {
+                                log::debug!("returning IP challenge cert for {}", sni);
+                                Some(cert.clone())
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None,
+                    }
                 }
                 Some(domain) => match &self.inner.lock().unwrap().challenge_data {
                     Some(ChallengeData::TlsAlpn01 { sni, cert }) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use crate::acceptor::AcmeAcceptor;
-use crate::acme::{Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus, ACME_TLS_ALPN_NAME};
+use crate::acme::{Account, AcmeError, Auth, AuthStatus, Directory, Order, OrderStatus, ACME_TLS_ALPN_NAME};
 use crate::{any_ecdsa_type, crypto_provider, AcmeConfig, Incoming, ResolvesServerCertAcme, UseChallenge};
 use async_io::Timer;
 use chrono::{DateTime, TimeZone, Utc};
@@ -307,7 +307,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         let auth = account.auth(&config.client_config, url).await?;
         let (domain, challenge_url) = match auth.status {
             AuthStatus::Pending => {
-                let Identifier::Dns(domain) = auth.identifier;
+                let domain = auth.identifier.into_inner();
                 log::info!("trigger challenge for {}", &domain);
                 let challenge = match config.challenge_type {
                     UseChallenge::Http01 => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use crate::acceptor::AcmeAcceptor;
-use crate::acme::{Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus, ACME_TLS_ALPN_NAME};
+use crate::acme::{Account, AcmeError, Auth, AuthStatus, Directory, Order, OrderStatus, ACME_TLS_ALPN_NAME};
 use crate::{any_ecdsa_type, crypto_provider, AcmeConfig, Incoming, ResolvesServerCertAcme, UseChallenge};
 use async_io::Timer;
 use chrono::{DateTime, TimeZone, Utc};
@@ -191,7 +191,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             early_action: None,
             load_cert: Some(Box::pin({
                 let config = config.clone();
-                async move { config.cache.load_cert(&config.domains, &config.directory_url).await }
+                async move { config.cache.load_cert(&config.all_domains(), &config.directory_url).await }
             })),
             load_account: Some(Box::pin({
                 let config = config.clone();
@@ -245,7 +245,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         }
         let config = self.config.clone();
         self.early_action = Some(Box::pin(async move {
-            match config.cache.store_cert(&config.domains, &config.directory_url, &pem).await {
+            match config.cache.store_cert(&config.all_domains(), &config.directory_url, &pem).await {
                 Ok(()) => Ok(EventOk::CertCacheStore),
                 Err(err) => Err(EventError::CertCacheStore(err)),
             }
@@ -256,12 +256,12 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         let directory = Directory::discover(&config.client_config, &config.directory_url).await?;
         let account = Account::create_with_keypair(&config.client_config, directory, &config.contact, &key_pair).await?;
 
-        let mut params = CertificateParams::new(config.domains.clone())?;
+        let mut params = CertificateParams::new(config.all_domains())?;
         params.distinguished_name = DistinguishedName::new();
         let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)?;
         let csr = params.serialize_request(&key_pair)?;
 
-        let (order_url, mut order) = account.new_order(&config.client_config, config.domains.clone()).await?;
+        let (order_url, mut order) = account.new_order(&config.client_config, config.all_domains()).await?;
         loop {
             match order.status {
                 OrderStatus::Pending => {
@@ -307,8 +307,8 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         let auth = account.auth(&config.client_config, url).await?;
         let (domain, challenge_url) = match auth.status {
             AuthStatus::Pending => {
-                let Identifier::Dns(domain) = auth.identifier;
-                log::info!("trigger challenge for {}", domain);
+                let domain = auth.identifier.clone().into_inner();
+                log::info!("trigger challenge for {}", &domain);
                 let challenge = match config.challenge_type {
                     UseChallenge::Http01 => {
                         let (challenge, key_auth) = account.http_01(&auth.challenges)?;
@@ -317,7 +317,14 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                     }
                     UseChallenge::TlsAlpn01 => {
                         let (challenge, auth_key) = account.tls_alpn_01(&auth.challenges, domain.clone())?;
-                        resolver.set_tls_alpn_01_challenge_data(domain.clone(), Arc::new(auth_key));
+                        // For IP identifiers, use reverse-DNS (ARPA) format as the SNI,
+                        // because RFC 8738 §6 requires the CA to send SNI in ARPA format
+                        // (RFC 6066 does not permit IP addresses in SNI).
+                        let sni = match &auth.identifier {
+                            crate::acme::Identifier::Ip(addr) => crate::acme::ip_to_arpa(*addr),
+                            crate::acme::Identifier::Dns(_) => domain.clone(),
+                        };
+                        resolver.set_tls_alpn_01_challenge_data(sni, Arc::new(auth_key));
                         challenge
                     }
                 };
@@ -340,7 +347,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             let auth = account.auth(&config.client_config, url).await?;
             match auth.status {
                 AuthStatus::Pending => {
-                    log::info!("authorization for {} still pending", domain);
+                    log::info!("authorization for {} still pending", &domain);
                     account.challenge(&config.client_config, &challenge_url).await?
                 }
                 AuthStatus::Valid => {


### PR DESCRIPTION
Adds support for ACME orders for IP addresses in addition to DNS names.

Related Issue #89 