### PR TITLE
Fix challenge deserialization for token-less challenge types

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -221,6 +221,7 @@ pub struct Challenge {
     #[serde(rename = "type")]
     pub typ: ChallengeType,
     pub url: String,
+    #[serde(default)]
     pub token: String,
     pub error: Option<Problem>,
 }


### PR DESCRIPTION
RFC 8555 only requires a token field for specific challenge types (http-01, dns-01, tls-alpn-01). Newer challenge types such as dns-persist-01 omit it. Add #[serde(default)] to the challenge token so deserialization does not fail when the field is absent.